### PR TITLE
Update to publish dockpulp-ansible to galaxy collection

### DIFF
--- a/.github/workflows/ansiblegalaxy.yml
+++ b/.github/workflows/ansiblegalaxy.yml
@@ -1,0 +1,28 @@
+name: Upload Ansible Galaxy Package
+
+on:
+  push:
+    branches:
+    - master
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        # python -m pip install --upgrade pip
+        pip install ansible
+        sudo apt-get install pandoc
+    - name: Build and publish
+      env:
+        GALAXY_API_KEY: ${{ secrets.GALAXY_API_KEY }}
+      run: |
+        ./build-collection
+        cd _build
+        ansible-galaxy collection publish release_engineering-dockpulp_ansible-*.tar.gz --api-key=${GALAXY_API_KEY}

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,17 @@
-# dockpulp-ansible
-========================
-This ``dockpulp_repo`` module can be used by git clone in ansible playbook only
-because it has not worked as a collection.
+Install from Ansible Galaxy
+---------------------------
+
+We distribute dockpulp-ansible through the `Ansible Galaxy
+<https://galaxy.ansible.com/release_engineering/dockpulp_ansible>`_.
+
+If you are using Ansible 2.9 or greater, you can `install
+<https://docs.ansible.com/ansible/latest/user_guide/collections_using.html>`_
+dockpulp_ansible like:
+
+  ansible-galaxy collection install release_engineering.dockpulp_ansible
+
+This will install the latest Git snapshot automatically. Use ``--force``
+upgrade your installed version to the latest version.
 
 
 dockpulp_repo
@@ -20,25 +30,26 @@ and three configuration files for dockpulp server
 
 * dockpulpdistributors.json
 
+
+The playbook.yml file is a small playbook that simply loads our module:
+
 .. code-block:: yaml
 
-    - name: create dockpulp repositories on rhel9
-      hosts: localhost
-      tasks:
-      - name: Add rhceph-4-tools-for-rhel-9-x86_64-rpms cdn repo
-        dockpulp_repo:
-          env: stage
-          dockpulp_user: fakeuser
-          dockpulp_password: fakeuserPassw0rd
-          repo_name: rhceph-4-rhel9
-          namespace: rhceph
-          content_url: /content/dist/containers/rhel9/multiarch/containers/redhat-rhceph-rhceph-4-rhel9
-          description: This is a test repo for create dockpulp repo
-          distribution: ga
-
+  - name: create dockpulp repositories on rhel9
+    hosts: localhost
+    collections:
+      - release_engineering.dockpulp_ansible
+    tasks:
+    - name: Add rhceph-4-tools-for-rhel-9-x86_64-rpms cdn repo
+      dockpulp_repo:
+        env: stage
+        dockpulp_user: fakeuser
+        dockpulp_password: fakeuserPassw0rd
+        repo_name: rhceph-4-rhel9
+        namespace: rhceph
+        content_url: /content/dist/containers/rhel9/multiarch/containers/redhat-rhceph-rhceph-4-rhel9
+        description: This is a test repo for create dockpulp repo
+        distribution: ga
 
 Next
 ----
-
-Make it be able to be used as a collection
-

--- a/build-collection
+++ b/build-collection
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -eux
+
+# Construct our Ansible Collection in a temporary "_build" directory.
+
+TOPDIR=$(dirname "$(readlink -f "$0")")
+
+cd $TOPDIR
+
+rm -rf _build
+mkdir _build
+cd _build
+
+mkdir plugins
+cp $TOPDIR/COPYING .
+cp -r $TOPDIR/meta/ .
+cp -r $TOPDIR/library/ plugins/modules
+cp -r $TOPDIR/module_utils/ plugins/module_utils/
+
+
+# Make our dockpulp_common imports compatible with Ansible Collections.
+sed -i \
+  -e  's/from ansible.module_utils.dockpulp_common/from ansible_collections.release_engineering.dockpulp_ansible.plugins.module_utils.dockpulp_common/' \
+  plugins/modules/*.py
+
+# Convert README from reStructuredText to Markdown.
+# Ansible Galaxy's Markdown engine plays best with markdown_strict.
+pandoc $TOPDIR/README.rst -f rst -t markdown_strict -o README.md
+
+# Determine our semver-compatible version number from Git.
+BASE_REF="${GITHUB_BASE_REF:-HEAD}"
+BASE_COMMIT=$(git rev-list --max-parents=0 $BASE_REF)
+COMMIT_COUNT=$(($(git rev-list --count $BASE_COMMIT..HEAD) - 1))
+
+# Versions will always be 0.1.XXX.
+VERSION="0.1.${COMMIT_COUNT}"
+
+sed $TOPDIR/galaxy.yml -e "s/{{ version }}/$VERSION/" > galaxy.yml
+
+ansible-galaxy collection build

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: release_engineering
 name: dockpulp_ansible
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 0.1.0
+version: "{{ version }}"
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/library/dockpulp_repo.py
+++ b/library/dockpulp_repo.py
@@ -1,4 +1,3 @@
-"""Module for creating repository in docker pulp server"""
 import subprocess
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.dockpulp_common import diff_settings, describe_changes
@@ -11,12 +10,13 @@ ANSIBLE_METADATA = {
 }
 
 
-DOCUMENTATION = """
+DOCUMENTATION = '''
 ---
 module: dockpulp_repo
+
 short_description: Create and update dockpulp repositories in Docker Pulp server
 description:
-   - Create and update CDN repositories within Red Hat's Docker Pulp server.
+- Create and update CDN repositories within Red Hat's Docker Pulp server.
 options:
    env:
      description:
@@ -24,11 +24,9 @@ options:
        - "Example: stage"
    dockpulp_user:
        - The user to login to docker pulp server
-       - "Example: fakeuser"
    dockpulp_password:
      description:
        - The password to login to docker pulp server
-       - "Example: fakeuserPassw0rd"
    repo_name:
      description:
        - Pulp repo label.
@@ -38,7 +36,7 @@ options:
      description:
        - Use like the 'product-line' value in release engineering documentation.
          Final value will have redhat prepended where necessary. This entry will
-         be used for the following:
+         be used for the following
        - "Example: rhceph"
      required: true
    content_url:
@@ -66,9 +64,9 @@ requirements:
   - "python >= 3.6"
   - "lxml"
   - "requests-gssapi"
-"""
+'''
 
-EXAMPLES = """
+EXAMPLES = '''
 - name: create dockpulp repositories on rhel8
   hosts: localhost
   tasks:
@@ -95,7 +93,7 @@ EXAMPLES = """
       content_url: /content/dist/containers/rhel9/multiarch/containers/redhat-rhceph-rhceph-4-rhel9
       description: This is a test repo for create dockpulp repo
       distribution: ga
-"""
+'''
 
 DOCK_PULP_TIMEOUT = 120
 

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,0 +1,1 @@
+requires_ansible: ">=2"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-ansible==2.8.0
-requests
+ansible; python_version>='3.8'
+ansible<5.0; python_version<='3.7'
 dictdiffer==0.8.1
+requests


### PR DESCRIPTION
This PR is submitted to publish dockpulp-ansible to ansible galaxy collection. 

Besides, collection namespace `release_engineering` in https://galaxy.ansible.com doesn't exist yet, so we need to request namespace `release_engineering` then we can publish to namespace `release_engineering`.

I think https://galaxy.ansible.com/docs/contributing/namespaces.html#requesting-additional-namespaces is the guide to request collection namespace `release_engineering`.

cc @ktdreyer Could you take a look at this PR and check if my understanding is correct? Thank you!